### PR TITLE
30 move changes from crypto3 zk up to commit ebac50db

### DIFF
--- a/include/nil/actor/zk/commitments/detail/polynomial/basic_fri.hpp
+++ b/include/nil/actor/zk/commitments/detail/polynomial/basic_fri.hpp
@@ -604,7 +604,7 @@ namespace nil {
                                     FRI>::value,
                             bool>::type = true>
                 static typename FRI::proof_type proof_eval(
-                    std::map<std::size_t, std::vector<PolynomialType>> &g,
+                    const std::map<std::size_t, std::vector<PolynomialType>> &g,
                     const PolynomialType combined_Q,
                     const std::map<std::size_t, typename FRI::precommitment_type> &precommitments,
                     const typename FRI::precommitment_type &combined_Q_precommitment,
@@ -616,17 +616,22 @@ namespace nil {
                     BOOST_ASSERT(check_step_list<FRI>(fri_params));
                     // TODO: add necessary checks
                     //BOOST_ASSERT(check_initial_precommitment<FRI>(precommitments, fri_params));
-                    if constexpr (std::is_same<math::polynomial_dfs<typename FRI::field_type::value_type>, PolynomialType>::value) {
-                        for(auto const &it : g) {
-                            auto k = it.first;
-                            for (int i = 0; i < g[k].size(); ++i ) {
-                                // If LPC works properly this if is never executed.
-                                if (g[k][i].size() != fri_params.D[0]->size()) {
-                                    g[k][i].resize(fri_params.D[0]->size()).get();
-                                }
-                            }
-                        }
-                    }
+
+                    // These resizes actually happens when called at the end of prover:
+                    // _proof.eval_proof.eval_proof = _commitment_scheme.proof_eval(transcript);
+                    // We DO NOT resize it here, it takes waaay too much RAM, resize it when needed.
+
+                    //if constexpr (std::is_same<math::polynomial_dfs<typename FRI::field_type::value_type>, PolynomialType>::value) {
+                    //    for( auto const &it:g ){
+                    //        auto k = it.first;
+                    //        for (int i = 0; i < g[k].size(); ++i ){
+                    //            // If LPC works properly this if is never executed.
+                    //            if (g[k][i].size() != fri_params.D[0]->size()) {
+                    //                g[k][i].resize(fri_params.D[0]->size());
+                    //            }
+                    //        }
+                    //    }
+                    //}
 
                     // Commit phase
                     auto f = combined_Q;
@@ -675,6 +680,25 @@ namespace nil {
 
                     // Query phase
                     std::array<typename FRI::query_proof_type, FRI::lambda> query_proofs;
+
+                    // If we have DFS polynomials, and we are going to resize them, better convert them to coefficients form,
+                    // and compute their values in those 2 * FRI::lambda points each, which is normally 2 * 20.
+                    // In case lambda becomes much larger than log(2, average polynomial size), then this will not be optimal.
+                    // For lambda = 20 and 2^20 rows in assignment table, it's faster and uses less RAM.
+                    std::map<std::size_t, std::vector<math::polynomial<typename FRI::field_type::value_type>>> g_coeffs;
+                    if constexpr (std::is_same<
+                        math::polynomial_dfs<typename FRI::field_type::value_type>,
+                        PolynomialType>::value
+                    ) {
+                        for (const auto &[key, poly_vector]: g) {
+                            for (const auto& poly: poly_vector) {
+                                if (poly.size() != fri_params.D[0]->size()) {
+                                    g_coeffs[key].emplace_back(poly.coefficients());
+                                }
+                            }
+                        }
+                    }
+
                     for (std::size_t query_id = 0; query_id < FRI::lambda; query_id++) {
                         std::size_t domain_size = fri_params.D[0]->size();
                         std::uint64_t x_index = (transcript.template int_challenge<std::uint64_t>()) % domain_size;
@@ -687,7 +711,7 @@ namespace nil {
 
                         //Initial proof
                         std::map<std::size_t, typename FRI::initial_proof_type> initial_proof;
-                        for( const auto &it: g ){
+                        for (const auto &it: g) {
                             auto k = it.first;
                             initial_proof[k] = {};
                             initial_proof[k].values.resize(it.second.size());
@@ -697,25 +721,37 @@ namespace nil {
 
                             //Fill values
                             t = 0;
-                            for (std::size_t polynomial_index = 0; polynomial_index < g[k].size(); ++polynomial_index) {
+                            const auto& g_k = it.second; // g[k]
+
+                            for (std::size_t polynomial_index = 0; polynomial_index < g_k.size(); ++polynomial_index) {
                                 initial_proof[k].values[polynomial_index].resize(coset_size / FRI::m);
-                                for (std::size_t j = 0; j < coset_size / FRI::m; j++) {
-                                    if constexpr (std::is_same<
+                                if constexpr (std::is_same<
                                             math::polynomial_dfs<typename FRI::field_type::value_type>,
                                             PolynomialType>::value
                                     ) {
-                                        initial_proof[k].values[polynomial_index][j][0] = std::move(g[k][polynomial_index][s_indices[j][0]]);
-                                        initial_proof[k].values[polynomial_index][j][1] = std::move(g[k][polynomial_index][s_indices[j][1]]);
+                                    if (g_k[polynomial_index].size() == fri_params.D[0]->size()) {
+                                        for (std::size_t j = 0; j < coset_size / FRI::m; j++) {
+                                            initial_proof[k].values[polynomial_index][j][0] = g_k[polynomial_index][s_indices[j][0]];
+                                            initial_proof[k].values[polynomial_index][j][1] = g_k[polynomial_index][s_indices[j][1]];
+                                        }
                                     } else {
-                                        initial_proof[k].values[polynomial_index][j][0] = g[k][polynomial_index].evaluate(
-                                                s[j][0]);
-                                        initial_proof[k].values[polynomial_index][j][1] = g[k][polynomial_index].evaluate(
-                                                s[j][1]);
+                                        // Convert to coefficients form and evaluate. coset_size / FRI::m is usually just 1,
+                                        // It makes no sense to resize in dfs form to then use just 2 values in 2 points.
+                                        for (std::size_t j = 0; j < coset_size / FRI::m; j++) {
+                                            initial_proof[k].values[polynomial_index][j][0] = g_coeffs[k][polynomial_index].evaluate(s[j][0]);
+                                            initial_proof[k].values[polynomial_index][j][1] = g_coeffs[k][polynomial_index].evaluate(s[j][1]);
+                                        }
+                                    }
+                                } else {
+                                    // Same for poly in coefficients form.
+                                    for (std::size_t j = 0; j < coset_size / FRI::m; j++) {
+                                        initial_proof[k].values[polynomial_index][j][0] = g_k[polynomial_index].evaluate(s[j][0]);
+                                        initial_proof[k].values[polynomial_index][j][1] = g_k[polynomial_index].evaluate(s[j][1]);
                                     }
                                 }
                             }
 
-                            //Fill merkle proofs
+                            // Fill merkle proofs
                             initial_proof[k].p = make_proof_specialized<FRI>(
                                 get_folded_index<FRI>(x_index, fri_params.D[0]->size(), fri_params.step_list[0]),
                                 fri_params.D[0]->size(), precommitments.at(k)
@@ -766,13 +802,14 @@ namespace nil {
                                 round_proofs[i].y[0][1] = final_polynomial.evaluate(-x);
                             }
                         }
-                        typename FRI::query_proof_type query_proof = {initial_proof, round_proofs};
-                        query_proofs[query_id] = query_proof;
+                        typename FRI::query_proof_type query_proof = {std::move(initial_proof), std::move(round_proofs)};
+                        query_proofs[query_id] = std::move(query_proof);
                     }
 
-                    proof.fri_roots = fri_roots;
-                    proof.final_polynomial = final_polynomial;
-                    proof.query_proofs = query_proofs;
+                    proof.fri_roots = std::move(fri_roots);
+                    proof.final_polynomial = std::move(final_polynomial);
+                    proof.query_proofs = std::move(query_proofs);
+
                     return proof;//typename FRI::proof_type{fri_roots, final_polynomial, query_proofs};
                 }
 

--- a/include/nil/actor/zk/commitments/detail/polynomial/basic_fri.hpp
+++ b/include/nil/actor/zk/commitments/detail/polynomial/basic_fri.hpp
@@ -144,7 +144,7 @@ namespace nil {
 
                             const std::size_t max_degree;
                             const std::vector<std::shared_ptr<math::evaluation_domain<FieldType>>> D;
- 
+
                             // The total number of FRI-rounds, the sum of 'step_list'.
                             const std::size_t r;
                             const std::vector<std::size_t> step_list;
@@ -694,6 +694,9 @@ namespace nil {
                             for (const auto& poly: poly_vector) {
                                 if (poly.size() != fri_params.D[0]->size()) {
                                     g_coeffs[key].emplace_back(poly.coefficients());
+                                } else {
+                                    // These polynomials won't be used
+                                    g_coeffs[key].emplace_back(math::polynomial<typename FRI::field_type::value_type>());
                                 }
                             }
                         }

--- a/include/nil/actor/zk/commitments/polynomial/kzg.hpp
+++ b/include/nil/actor/zk/commitments/polynomial/kzg.hpp
@@ -688,7 +688,7 @@ namespace nil {
 
                         std::vector<std::uint8_t> result = {};
                         for (std::size_t i = 0; i < this->_polys[index].size(); ++i) {
-                            BOOST_ASSERT(this->_polys[index][i].size() <= _params.commitment_key.size());
+                            BOOST_ASSERT(this->_polys[index][i].degree() <= _params.commitment_key.size());
                             auto single_commitment = nil::actor::zk::algorithms::commit_one<KZGScheme>(_params, this->_polys[index][i]);
                             this->_ind_commitments[index].push_back(single_commitment);
                             auto single_commitment_bytes = KZGScheme::serializer::point_to_octets(single_commitment);

--- a/include/nil/actor/zk/snark/arithmetization/plonk/assignment.hpp
+++ b/include/nil/actor/zk/snark/arithmetization/plonk/assignment.hpp
@@ -83,6 +83,10 @@ namespace nil {
                         return _witnesses;
                     }
 
+                    witnesses_container_type move_witnesses() {
+                        return std::move(_witnesses);
+                    }
+
                     const ColumnType& operator[](std::uint32_t index) const {
                         if (index < ArithmetizationParams::witness_columns)
                             return _witnesses[index];
@@ -149,6 +153,10 @@ namespace nil {
                         return _public_inputs;
                     }
 
+                    public_input_container_type move_public_inputs() {
+                        return std::move(_public_inputs);
+                    }
+
                     std::uint32_t constants_amount() const {
                         return _constants.size();
                     }
@@ -166,6 +174,11 @@ namespace nil {
                         return _constants;
                     }
 
+                    constant_container_type move_constants() {
+
+                        return std::move(_constants);
+                    }
+
                     constexpr std::uint32_t selectors_amount() const {
                         return _selectors.size();
                     }
@@ -181,6 +194,11 @@ namespace nil {
 
                     const selector_container_type& selectors() const {
                         return _selectors;
+                    }
+
+                    selector_container_type move_selectors() {
+
+                        return std::move(_selectors);
                     }
 
                     virtual void fill_constant(std::uint32_t index, const ColumnType& column) {
@@ -248,6 +266,7 @@ namespace nil {
                     using selector_container_type = typename public_table_type::selector_container_type;
 
                 protected:
+                    // These are normally created by the assigner, or read from a file.
                     private_table_type _private_table;
                     public_table_type _public_table;
 
@@ -311,8 +330,16 @@ namespace nil {
                         return _private_table;
                     }
 
+                    private_table_type move_private_table() {
+                        return std::move(_private_table);
+                    }
+
                     const public_table_type& public_table() const {
                         return _public_table;
+                    }
+
+                    public_table_type move_public_table() {
+                        return std::move(_public_table);
                     }
 
                     std::uint32_t size() const {

--- a/include/nil/actor/zk/snark/arithmetization/plonk/detail/column_polynomial.hpp
+++ b/include/nil/actor/zk/snark/arithmetization/plonk/detail/column_polynomial.hpp
@@ -89,8 +89,8 @@ namespace nil {
 
                     template<typename FieldType>
                     future<math::polynomial_dfs<typename FieldType::value_type>>
-                        column_polynomial_dfs(const plonk_column<FieldType> &column_assignment,
-                                          const std::shared_ptr<math::evaluation_domain<FieldType>> &domain) {
+                        column_polynomial_dfs(plonk_column<FieldType> column_assignment,
+                                              std::shared_ptr<math::evaluation_domain<FieldType>> domain) {
 
                         std::size_t d = std::distance(column_assignment.begin(), column_assignment.end()) - 1;
 
@@ -104,15 +104,15 @@ namespace nil {
 
                     template<typename FieldType>
                     std::vector<math::polynomial_dfs<typename FieldType::value_type>>
-                        column_range_polynomial_dfs(const std::vector<plonk_column<FieldType>> &column_range_assignment,
-                                                 const std::shared_ptr<math::evaluation_domain<FieldType>> &domain) {
+                        column_range_polynomial_dfs(std::vector<plonk_column<FieldType>> column_range_assignment,
+                                                    std::shared_ptr<math::evaluation_domain<FieldType>> domain) {
 
                         std::size_t columns_amount = column_range_assignment.size();
                         std::vector<math::polynomial_dfs<typename FieldType::value_type>> columns(columns_amount);
 
                         for (std::size_t column_index = 0; column_index < columns_amount; column_index++) {
                             columns[column_index] =
-                                column_polynomial_dfs<FieldType>(column_range_assignment[column_index], domain);
+                                column_polynomial_dfs<FieldType>(std::move(column_range_assignment[column_index]), domain);
                         }
 
                         return columns;
@@ -121,14 +121,14 @@ namespace nil {
                     template<typename FieldType, std::size_t columns_amount>
                     future<std::array<math::polynomial_dfs<typename FieldType::value_type>, columns_amount>>
                         column_range_polynomial_dfs(
-                            const std::array<plonk_column<FieldType>, columns_amount> &column_range_assignment,
-                            const std::shared_ptr<math::evaluation_domain<FieldType>> &domain) {
+                            std::array<plonk_column<FieldType>, columns_amount> column_range_assignment,
+                            std::shared_ptr<math::evaluation_domain<FieldType>> domain) {
 
                         std::array<math::polynomial_dfs<typename FieldType::value_type>, columns_amount> columns;
 
                         for (std::size_t column_index = 0; column_index < columns_amount; column_index++) {
                             columns[column_index] =
-                                column_polynomial_dfs<FieldType>(column_range_assignment[column_index], domain).get();
+                                column_polynomial_dfs<FieldType>(std::move(column_range_assignment[column_index]), domain).get();
                         }
 
                         return make_ready_future<std::array<math::polynomial_dfs<typename FieldType::value_type>, columns_amount>>(columns);

--- a/include/nil/actor/zk/snark/systems/plonk/placeholder/lookup_argument.hpp
+++ b/include/nil/actor/zk/snark/systems/plonk/placeholder/lookup_argument.hpp
@@ -4,6 +4,7 @@
 // Copyright (c) 2022 Ilia Shirobokov <i.shirobokov@nil.foundation>
 // Copyright (c) 2022 Alisa Cherniaeva <a.cherniaeva@nil.foundation>
 // Copyright (c) 2023 Elena Tatuzova <e.tatuzova@nil.foundation>
+// Copyright (c) 2023 Martun Karapetyan <martun@nil.foundation>
 //
 // MIT License
 //
@@ -52,7 +53,7 @@ namespace nil {
         namespace zk {
             namespace snark {
                 template<typename FieldType, typename CommitmentSchemeTypePermutation, typename ParamsType>
-                class placeholder_lookup_argument {
+                class placeholder_lookup_argument_prover {
                     using transcript_hash_type = typename ParamsType::transcript_hash_type;
                     using transcript_type = transcript::fiat_shamir_heuristic_sequential<transcript_hash_type>;
                     using polynomial_dfs_type = math::polynomial_dfs<typename FieldType::value_type>;
@@ -66,34 +67,338 @@ namespace nil {
                     typedef detail::placeholder_policy<FieldType, ParamsType> policy_type;
 
                 public:
-                    static math::polynomial_dfs<typename FieldType::value_type> reduce_dfs_polynomial_domain(
+
+                    struct prover_lookup_result {
+                        std::array<math::polynomial_dfs<typename FieldType::value_type>, argument_size> F_dfs;
+                        typename commitment_scheme_type::commitment_type lookup_commitment;
+                    };
+
+                    placeholder_lookup_argument_prover(
+                            const plonk_constraint_system<FieldType, typename ParamsType::arithmetization_params>
+                                &constraint_system,
+                            const typename placeholder_public_preprocessor<FieldType, ParamsType>::preprocessed_data_type
+                                &preprocessed_data,
+                            const plonk_polynomial_dfs_table<FieldType, typename ParamsType::arithmetization_params>
+                                &plonk_columns,
+                            commitment_scheme_type &commitment_scheme,
+                            transcript_type &transcript)
+                        : constraint_system(constraint_system)
+                        , preprocessed_data(preprocessed_data)
+                        , plonk_columns(plonk_columns)
+                        , commitment_scheme(commitment_scheme)
+                        , transcript(transcript)
+                        , basic_domain(preprocessed_data.common_data.basic_domain)
+                        , lookup_gates(constraint_system.lookup_gates())
+                        , lookup_tables(constraint_system.lookup_tables())
+                    {
+                        // $/theta = \challenge$
+                        theta = transcript.template challenge<FieldType>();
+                    }
+
+                    prover_lookup_result prove_eval() {
+                        PROFILE_PLACEHOLDER_SCOPE("Lookup argument prove eval time");
+
+                        // Construct lookup gates
+                        math::polynomial_dfs<typename FieldType::value_type> one_polynomial(
+                            0, basic_domain->m, FieldType::value_type::one());
+                        math::polynomial_dfs<typename FieldType::value_type> zero_polynomial(
+                            0, basic_domain->m, FieldType::value_type::zero());      
+                        math::polynomial_dfs<typename FieldType::value_type> mask_assignment = 
+                            one_polynomial -  preprocessed_data.q_last - preprocessed_data.q_blind;
+
+                        std::unique_ptr<std::vector<math::polynomial_dfs<typename FieldType::value_type>>> lookup_value_ptr = 
+                            prepare_lookup_value(mask_assignment);
+                        auto& lookup_value = *lookup_value_ptr;
+                        
+                        std::unique_ptr<std::vector<math::polynomial_dfs<typename FieldType::value_type>>> lookup_input_ptr = 
+                            prepare_lookup_input();
+                        auto& lookup_input = *lookup_input_ptr;
+                        
+                        // 3. Lookup_input and lookup_value are ready
+                        //    Now sort them!
+                        //    Reduce value and input:
+                        auto reduced_value_ptr = std::make_unique<std::vector<math::polynomial_dfs<typename FieldType::value_type>>>();
+                        auto& reduced_value = *reduced_value_ptr;
+
+                        for( std::size_t i = 0; i < lookup_value.size(); i++ ){
+                            reduced_value.push_back(reduce_dfs_polynomial_domain(lookup_value[i], basic_domain->m));
+                        }
+                        auto reduced_input_ptr = std::make_unique<std::vector<math::polynomial_dfs<typename FieldType::value_type>>>();
+                        auto& reduced_input = *reduced_input_ptr;
+
+                        for( std::size_t i = 0; i < lookup_input.size(); i++ ){
+                            reduced_input.push_back(reduce_dfs_polynomial_domain(lookup_input[i], basic_domain->m));
+                        }
+                        //    Sort
+                        auto sorted = sort_polynomials(reduced_input, reduced_value, basic_domain->m,
+                            preprocessed_data.common_data.usable_rows_amount);
+
+                        // 4. Commit sorted polys
+                        for( std::size_t i = 0; i < sorted.size(); i++){
+                            commitment_scheme.append_to_batch(LOOKUP_BATCH, sorted[i]);
+                        }
+                        typename commitment_scheme_type::commitment_type lookup_commitment = commitment_scheme.commit(LOOKUP_BATCH);
+                        transcript(lookup_commitment);
+
+                        //5. Compute V_L polynomial.
+                        typename FieldType::value_type beta  = transcript.template challenge<FieldType>();
+                        typename FieldType::value_type gamma = transcript.template challenge<FieldType>();
+
+                        math::polynomial_dfs<typename FieldType::value_type> V_L = compute_V_L(
+                            sorted, reduced_input, reduced_value, beta, gamma);
+
+                        // We don't use reduced_input and reduced_value after this line.
+                        reduced_input_ptr.reset(nullptr);
+                        reduced_value_ptr.reset(nullptr);
+
+                        commitment_scheme.append_to_batch(PERMUTATION_BATCH, V_L);
+
+                        BOOST_CHECK(V_L[preprocessed_data.common_data.usable_rows_amount] ==  FieldType::value_type::one());
+                        
+                        // After this call of compute_g lookup_input_ptr and lookup_value_ptr are deleted.
+                        math::polynomial_dfs<typename FieldType::value_type> g = compute_g(
+                            std::move(lookup_input_ptr), std::move(lookup_value_ptr), beta, gamma);
+
+                        math::polynomial_dfs<typename FieldType::value_type> h = compute_h(sorted, beta, gamma);
+                        math::polynomial_dfs<typename FieldType::value_type> V_L_shifted =
+                            math::polynomial_shift(V_L, 1, basic_domain->m).get();
+
+                        std::array<math::polynomial_dfs<typename FieldType::value_type>, argument_size> F_dfs;
+
+                        F_dfs[0] = preprocessed_data.common_data.lagrange_0 * (one_polynomial - V_L);
+                        F_dfs[1] = preprocessed_data.q_last * ( V_L * V_L - V_L );
+
+                        // Polynomial g is waaay too large, saving memory here, by making code very unreadable.
+                        //F_dfs[2] = (one_polynomial - (preprocessed_data.q_last + preprocessed_data.q_blind)) *
+                        //           (V_L_shifted * h - V_L * g);
+                        g *= V_L;
+                        h *= V_L_shifted;
+                        g -= h;
+                        h = math::polynomial_dfs<typename FieldType::value_type>(); // just clean the memory of h.
+                        g *= (preprocessed_data.q_last + preprocessed_data.q_blind) - one_polynomial;
+                        F_dfs[2] = std::move(g);
+
+                        F_dfs[3] = zero_polynomial;
+
+                        for (std::size_t i = 1; i < sorted.size(); i++) {
+                            typename FieldType::value_type alpha =  transcript.template challenge<FieldType>();
+                            math::polynomial_dfs sorted_shifted = math::polynomial_shift(
+                                sorted[i-1], preprocessed_data.common_data.usable_rows_amount , basic_domain->m).get();
+                            F_dfs[3] += alpha * preprocessed_data.common_data.lagrange_0 * (sorted[i] - sorted_shifted);
+                        }
+
+/*                        for( std::size_t i = 0; i < basic_domain->m; i++){
+                            BOOST_CHECK( F_dfs[0].evaluate(basic_domain->get_domain_element(i)) == FieldType::value_type::zero() );
+                            BOOST_CHECK( F_dfs[1].evaluate(basic_domain->get_domain_element(i)) == FieldType::value_type::zero() );
+                            BOOST_CHECK( F_dfs[2].evaluate(basic_domain->get_domain_element(i)) == FieldType::value_type::zero() );
+                            BOOST_CHECK( F_dfs[3].evaluate(basic_domain->get_domain_element(i)) == FieldType::value_type::zero() );
+                        }*/
+
+                        return {
+                            std::move(F_dfs),
+                            std::move(lookup_commitment)
+                        };
+                    }
+
+                    math::polynomial_dfs<typename FieldType::value_type> compute_g(
+                            std::unique_ptr<std::vector<math::polynomial_dfs<typename FieldType::value_type>>> lookup_input_ptr,
+                            std::unique_ptr<std::vector<math::polynomial_dfs<typename FieldType::value_type>>> lookup_value_ptr,
+                            const typename FieldType::value_type& beta,
+                            const typename FieldType::value_type& gamma) {
+
+                        auto& lookup_value = *lookup_value_ptr;
+                        auto& lookup_input = *lookup_input_ptr;
+ 
+                        auto g = math::polynomial_dfs<typename FieldType::value_type>::one();
+                        auto one = FieldType::value_type::one();
+                        g *= (one + beta).pow(lookup_input.size());
+
+                        std::vector<math::polynomial_dfs<typename FieldType::value_type>> g_multipliers;
+                        for (std::size_t i = 0; i < lookup_input.size(); i++) {
+                            g_multipliers.push_back(gamma + lookup_input[i]);
+                        }
+
+                        // We don't use lookup_input after this line.
+                        lookup_input_ptr.reset(nullptr);
+
+                        auto part1 = (one+beta) * gamma;
+                        for (std::size_t i = 0; i < lookup_value.size(); i++) {
+                            auto lookup_shifted = math::polynomial_shift(lookup_value[i], 1, basic_domain->m).get();
+                            g_multipliers.push_back( part1 + lookup_value[i] + beta * lookup_shifted);
+                        }
+
+                        // We don't use lookup_value after this line.
+                        lookup_value_ptr.reset(nullptr);
+
+                        g *= polynomial_product(std::move(g_multipliers));
+                        return g;
+                    }
+
+                    math::polynomial_dfs<typename FieldType::value_type> compute_h(
+                            const std::vector<math::polynomial_dfs<typename FieldType::value_type>>& sorted,
+                            const typename FieldType::value_type& beta,
+                            const typename FieldType::value_type& gamma
+                        ) {
+                        auto one = FieldType::value_type::one();
+
+                        std::vector<math::polynomial_dfs<typename FieldType::value_type>> h_multipliers;
+                        for (std::size_t i = 0; i < sorted.size(); i++) {
+                            auto sorted_shifted = math::polynomial_shift(sorted[i], 1, basic_domain->m).get();
+                            h_multipliers.push_back((one + beta) * gamma + sorted[i] + beta * sorted_shifted);
+                        }
+                        return polynomial_product(h_multipliers);
+                    }
+
+                    math::polynomial_dfs<typename FieldType::value_type> compute_V_L(
+                        const std::vector<math::polynomial_dfs<typename FieldType::value_type>>& sorted,
+                        const std::vector<math::polynomial_dfs<typename FieldType::value_type>>& reduced_input,
+                        const std::vector<math::polynomial_dfs<typename FieldType::value_type>>& reduced_value, 
+                        const typename FieldType::value_type& beta,
+                        const typename FieldType::value_type& gamma) { 
+
+                        math::polynomial_dfs<typename FieldType::value_type> V_L(
+                            basic_domain->m-1,basic_domain->m, FieldType::value_type::zero());
+                        V_L[0] = FieldType::value_type::one();
+                        auto one = FieldType::value_type::one();
+
+                        for (std::size_t k = 1; k <= preprocessed_data.common_data.usable_rows_amount; k++) {
+                            V_L[k] = V_L[k-1];
+                        
+                            typename FieldType::value_type g_tmp = (one + beta).pow(reduced_input.size());
+                            for (std::size_t i = 0; i < reduced_input.size(); i++) {
+                                g_tmp *= gamma + reduced_input[i][k-1];
+                            }
+
+                            auto part1 = (one + beta) * gamma;
+                            for (std::size_t i = 0; i < reduced_value.size(); i++) {
+                                g_tmp *= part1 + reduced_value[i][k-1] + beta * reduced_value[i][k];
+                            }
+
+                            V_L[k] *= g_tmp;
+
+                            typename FieldType::value_type h_tmp = FieldType::value_type::one();
+                            for (std::size_t i = 0; i < sorted.size(); i++) {
+                                h_tmp *= part1 + sorted[i][k-1] + beta * sorted[i][k];
+                            }
+                            V_L[k] *= h_tmp.inversed();
+                        }
+                        return V_L;
+                    }
+
+                    std::unique_ptr<std::vector<math::polynomial_dfs<typename FieldType::value_type>>> prepare_lookup_value(
+                            const math::polynomial_dfs<typename FieldType::value_type>& mask_assignment) {
+                        typename FieldType::value_type theta_acc;
+
+                        // Prepare lookup value
+                        auto lookup_value_ptr = std::make_unique<std::vector<math::polynomial_dfs<typename FieldType::value_type>>>();
+                        for (std::size_t t_id = 0; t_id < lookup_tables.size(); t_id++) {
+                            const plonk_lookup_table<FieldType> &l_table = lookup_tables[t_id];
+                            const math::polynomial_dfs<typename FieldType::value_type> &lookup_tag = plonk_columns.selector(l_table.tag_index);
+                            for (std::size_t o_id = 0; o_id < l_table.lookup_options.size(); o_id++) {
+                                math::polynomial_dfs<typename FieldType::value_type> v = (typename FieldType::value_type(t_id + 1)) * lookup_tag;
+                                theta_acc = theta;
+                                for (std::size_t i = 0; i < l_table.columns_number; i++) {
+                                    v += theta_acc * lookup_tag * plonk_columns.constant(l_table.lookup_options[o_id][i].index);
+                                    theta_acc *= theta;
+                                }
+                                v *= mask_assignment;
+                                lookup_value_ptr->push_back(v);
+                            }
+                        }
+                        return std::move(lookup_value_ptr);
+                    }
+
+                    std::unique_ptr<std::vector<math::polynomial_dfs<typename FieldType::value_type>>> prepare_lookup_input() {
+                        // Copied from gate argument.
+                        // TODO: remove code duplication.
+                        auto value_type_to_polynomial_dfs = [&assignments=plonk_columns](
+                            const typename VariableType::assignment_type& coeff) {
+                                return polynomial_dfs_type(0, 1, coeff);
+                            };
+
+                        math::expression_variable_type_converter<VariableType, DfsVariableType> converter(
+                            value_type_to_polynomial_dfs);
+
+                        auto get_var_value = [&domain=basic_domain, &assignments=plonk_columns]
+                        (const DfsVariableType &var) {
+                            polynomial_dfs_type assignment;
+                            switch (var.type) {
+                                case DfsVariableType::column_type::witness:
+                                    assignment = assignments.witness(var.index);
+                                    break;
+                                case DfsVariableType::column_type::public_input:
+                                    assignment = assignments.public_input(var.index);
+                                    break;
+                                case DfsVariableType::column_type::constant:
+                                    assignment = assignments.constant(var.index);
+                                    break;
+                                case DfsVariableType::column_type::selector:
+                                    assignment = assignments.selector(var.index);
+                                    break;
+                            }
+
+                            if (var.rotation != 0) {
+                                assignment = math::polynomial_shift(assignment, var.rotation, domain->m).get();
+                            }
+                            return assignment;
+                        };
+
+                        typename FieldType::value_type theta_acc;
+
+                        // Prepare lookup input                        
+                        auto lookup_input_ptr = std::make_unique<std::vector<math::polynomial_dfs<typename FieldType::value_type>>>();
+                        for (const auto &gate : lookup_gates) {
+                            math::expression<DfsVariableType> expr; 
+                            math::polynomial_dfs<typename FieldType::value_type> lookup_selector = plonk_columns.selector(gate.tag_index);
+                            for (const auto &constraint : gate.constraints) {
+                                math::polynomial_dfs<typename FieldType::value_type> l = lookup_selector * (typename FieldType::value_type(constraint.table_id));
+                                theta_acc = theta;
+                                for(std::size_t k = 0; k < constraint.lookup_input.size(); k++){
+                                    expr = converter.convert(constraint.lookup_input[k]);
+                                    math::cached_expression_evaluator<DfsVariableType> evaluator(expr, get_var_value);
+
+                                    l += theta_acc * lookup_selector * evaluator.evaluate();
+                                    theta_acc *= theta;
+                                }
+                                lookup_input_ptr->push_back(l);
+                            }
+                        }
+                        return std::move(lookup_input_ptr);
+                    }
+
+
+                private:
+
+                    math::polynomial_dfs<typename FieldType::value_type> reduce_dfs_polynomial_domain(
                         const math::polynomial_dfs<typename FieldType::value_type> &polynomial,
                         std::size_t &new_domain_size
                     ) {
-                        math::polynomial_dfs<typename FieldType::value_type> reduced(new_domain_size - 1, new_domain_size, FieldType::value_type::zero());
+                        math::polynomial_dfs<typename FieldType::value_type> reduced(
+                            new_domain_size - 1, new_domain_size, FieldType::value_type::zero());
+
                         BOOST_ASSERT(new_domain_size <= polynomial.size());
-                        if(polynomial.size() == new_domain_size){
+                        if (polynomial.size() == new_domain_size) {
                             reduced = polynomial;
                         } else {
                             BOOST_ASSERT(polynomial.size() % new_domain_size == 0);
                         
                             std::size_t step = polynomial.size() / new_domain_size;
-                            for( std::size_t i = 0; i < new_domain_size; i ++){
-                                reduced[i] = polynomial[i*step];
+                            for (std::size_t i = 0; i < new_domain_size; i++) {
+                                reduced[i] = polynomial[i * step];
                             }
                         }
                         return reduced;
                     };
 
-                    static math::polynomial_dfs<typename FieldType::value_type> get_constraint_tag_from_gate_tag_column(
+                    math::polynomial_dfs<typename FieldType::value_type> get_constraint_tag_from_gate_tag_column(
                         math::polynomial_dfs<typename FieldType::value_type> tag_column, 
                         std::size_t constraints_num,
                         std::size_t constraint_id, 
                         std::size_t table_id
                     ){
                         math::polynomial_dfs<typename FieldType::value_type> result = tag_column;
-                        for( std::size_t i = 1; i <= constraints_num; i++ ){
-                            if( i != constraint_id ){
+                        for (std::size_t i = 1; i <= constraints_num; i++) {
+                            if (i != constraint_id) {
                                 auto tmp = tag_column - typename FieldType::value_type(i);
                                 tmp /=  (typename FieldType::value_type(constraint_id) - typename FieldType::value_type(i)); 
                                 result *= tmp;
@@ -104,15 +409,15 @@ namespace nil {
                         return result;
                     }
 
-                    static typename FieldType::value_type get_constraint_tag_value_from_gate_tag_value(
+                    typename FieldType::value_type get_constraint_tag_value_from_gate_tag_value(
                         typename FieldType::value_type tag_value, 
                         std::size_t constraints_num,
                         std::size_t constraint_id, 
                         std::size_t table_id
-                    ){
+                    ) {
                         typename FieldType::value_type result = tag_value;
-                        for( std::size_t i = 1; i <= constraints_num; i++ ){
-                            if( i != constraint_id ){
+                        for (std::size_t i = 1; i <= constraints_num; i++) {
+                            if (i != constraint_id) {
                                 auto tmp = tag_value - typename FieldType::value_type(i);
                                 tmp /= typename FieldType::value_type(constraint_id) - typename FieldType::value_type(i); 
                                 result *= tmp;
@@ -123,11 +428,6 @@ namespace nil {
                         return result;
                     }
 
-                    struct prover_lookup_result {
-                        std::array<math::polynomial_dfs<typename FieldType::value_type>, argument_size> F_dfs;
-                        typename commitment_scheme_type::commitment_type lookup_commitment;
-                    };
-
                     // Each lookup table should fill full rectangle inside assignment table
                     // Lookup tables may contain repeated values, but they shoul be placed into one
                     // option one under another. 
@@ -135,13 +435,12 @@ namespace nil {
                     // similar values only with negligible probability.
                     // So similar values in compressed lookup tables vectors repeated values may be only in one column 
                     // near each other.
-                    static inline std::vector<math::polynomial_dfs<typename FieldType::value_type>> sort_polynomials(
+                    std::vector<math::polynomial_dfs<typename FieldType::value_type>> sort_polynomials(
                         const std::vector<math::polynomial_dfs<typename FieldType::value_type>>& reduced_input,
                         const std::vector<math::polynomial_dfs<typename FieldType::value_type>>& reduced_value, 
                         std::size_t domain_size,
                         std::size_t usable_rows_amount
-                        
-                    ){
+                    ) {
                         //  Build sorting map
                         std::unordered_map<typename FieldType::value_type, std::size_t> sorting_map;
                         for (std::size_t i = 0; i < reduced_value.size(); i++) {
@@ -161,7 +460,8 @@ namespace nil {
                             }
                         }
 
-                        math::polynomial_dfs<typename FieldType::value_type> zero_poly(domain_size-1, domain_size, FieldType::value_type::zero());
+                        math::polynomial_dfs<typename FieldType::value_type> zero_poly(
+                            domain_size-1, domain_size, FieldType::value_type::zero());
                         std::vector<math::polynomial_dfs<typename FieldType::value_type>> sorted(
                             reduced_input.size() + reduced_value.size(), zero_poly
                         );
@@ -206,233 +506,49 @@ namespace nil {
                         return sorted;
                     }
 
-                    static inline math::polynomial_dfs<typename FieldType::value_type> polynomial_product(
+                    math::polynomial_dfs<typename FieldType::value_type> polynomial_product(
                         std::vector<math::polynomial_dfs<typename FieldType::value_type>> multipliers)
                     {
                         std::size_t stride = 1;
                         while (stride < multipliers.size() ) {
                             for(std::size_t i = 0; i + stride < multipliers.size(); i += stride*2) {
                                 multipliers[i] *= multipliers[ i + stride ];
+                                // Free the memeory we don't use. any more.
+                                multipliers[ i + stride ] = math::polynomial_dfs<typename FieldType::value_type>();
                             }
                             stride *= 2;
                         }
-                        return multipliers[0];
+                        return std::move(multipliers[0]);
                     }
 
-                    static inline prover_lookup_result prove_eval(
-                        const plonk_constraint_system<FieldType, typename ParamsType::arithmetization_params>
-                            &constraint_system,
-                        const typename placeholder_public_preprocessor<FieldType, ParamsType>::preprocessed_data_type
-                            &preprocessed_data,
-                        const plonk_polynomial_dfs_table<FieldType, typename ParamsType::arithmetization_params>
-                            &plonk_columns,
-                        commitment_scheme_type &commitment_scheme,
-                        transcript_type &transcript = transcript_type()
-                    ) {
-                        PROFILE_PLACEHOLDER_SCOPE("Lookup argument prove eval time");
+                    const plonk_constraint_system<FieldType, typename ParamsType::arithmetization_params>& constraint_system;
+                    const typename placeholder_public_preprocessor<FieldType, ParamsType>::preprocessed_data_type& preprocessed_data;
+                    const plonk_polynomial_dfs_table<FieldType, typename ParamsType::arithmetization_params>& plonk_columns;
+                    commitment_scheme_type& commitment_scheme;
+                    transcript_type& transcript;
+                    std::shared_ptr<math::evaluation_domain<FieldType>> basic_domain;
+                    const std::vector<plonk_lookup_gate<FieldType, plonk_lookup_constraint<FieldType>>>& lookup_gates;
+                    const std::vector<plonk_lookup_table<FieldType>>& lookup_tables;
+                    typename FieldType::value_type theta;
 
-                        // Copied from gate argument.
-                        // TODO: remove code duplication.
-                        auto value_type_to_polynomial_dfs = [&assignments=plonk_columns](
-                            const typename VariableType::assignment_type& coeff) {
-                                return polynomial_dfs_type(0, 1, coeff);
-                            };
+                };
 
-                        math::expression_variable_type_converter<VariableType, DfsVariableType> converter(
-                            value_type_to_polynomial_dfs);
-
-                        std::shared_ptr<math::evaluation_domain<FieldType>> basic_domain =
-                            preprocessed_data.common_data.basic_domain;
-
-                        auto get_var_value = [&domain=basic_domain, &assignments=plonk_columns]
-                        (const DfsVariableType &var) {
-                            polynomial_dfs_type assignment;
-                            switch (var.type) {
-                                case DfsVariableType::column_type::witness:
-                                    assignment = assignments.witness(var.index);
-                                    break;
-                                case DfsVariableType::column_type::public_input:
-                                    assignment = assignments.public_input(var.index);
-                                    break;
-                                case DfsVariableType::column_type::constant:
-                                    assignment = assignments.constant(var.index);
-                                    break;
-                                case DfsVariableType::column_type::selector:
-                                    assignment = assignments.selector(var.index);
-                                    break;
-                            }
-
-                            if (var.rotation != 0) {
-                                assignment = math::polynomial_shift(assignment, var.rotation, domain->m).get();
-                            }
-                            return assignment;
-                        };
+                template<typename FieldType, typename CommitmentSchemeTypePermutation, typename ParamsType>
+                class placeholder_lookup_argument_verifier {
+                    using transcript_hash_type = typename ParamsType::transcript_hash_type;
+                    using transcript_type = transcript::fiat_shamir_heuristic_sequential<transcript_hash_type>;
+                    using polynomial_dfs_type = math::polynomial_dfs<typename FieldType::value_type>;
+                    using VariableType = plonk_variable<typename FieldType::value_type>;
+                    using DfsVariableType = plonk_variable<polynomial_dfs_type>;
+                    using commitment_scheme_type = CommitmentSchemeTypePermutation;
 
 
-                        prover_lookup_result result;
+                    static constexpr std::size_t argument_size = 4;
 
-                        // $/theta = \challenge$
-                        typename FieldType::value_type theta = transcript.template challenge<FieldType>();
-                        typename FieldType::value_type theta_acc;
-                        
-                        // Construct lookup gates
-                        const std::vector<plonk_lookup_gate<FieldType, plonk_lookup_constraint<FieldType>>> &lookup_gates =
-                            constraint_system.lookup_gates();
+                    typedef detail::placeholder_policy<FieldType, ParamsType> policy_type;
 
-                        const std::vector<plonk_lookup_table<FieldType>> &lookup_tables = constraint_system.lookup_tables();
-                        std::array<math::polynomial_dfs<typename FieldType::value_type>, argument_size> F_dfs;
-
-                        math::polynomial_dfs<typename FieldType::value_type> one_polynomial(
-                            0, basic_domain->m, FieldType::value_type::one());
-                        math::polynomial_dfs<typename FieldType::value_type> zero_polynomial(
-                            0, basic_domain->m, FieldType::value_type::zero());      
-                        math::polynomial_dfs<typename FieldType::value_type> mask_assignment = 
-                            one_polynomial -  preprocessed_data.q_last - preprocessed_data.q_blind;
-
-                        // Prepare lookup value
-                        std::vector<math::polynomial_dfs<typename FieldType::value_type>> lookup_value;
-                        for(std::size_t t_id = 0; t_id < lookup_tables.size(); t_id++){
-                            const plonk_lookup_table<FieldType> &l_table = lookup_tables[t_id];
-                            const math::polynomial_dfs<typename FieldType::value_type> &lookup_tag = plonk_columns.selector(l_table.tag_index);
-                            for( std::size_t o_id = 0; o_id < l_table.lookup_options.size(); o_id++ ){
-                                math::polynomial_dfs<typename FieldType::value_type> v = (typename FieldType::value_type(t_id + 1)) * lookup_tag;
-                                theta_acc = theta;
-                                for(std::size_t i = 0; i < l_table.columns_number; i++) {
-                                    v += theta_acc * lookup_tag * plonk_columns.constant(l_table.lookup_options[o_id][i].index);
-                                    theta_acc *= theta;
-                                }
-                                v *= mask_assignment;
-                                auto reduced_v = reduce_dfs_polynomial_domain(v, basic_domain->m);
-                                lookup_value.push_back(v);
-                            }
-                        }
-
-                        // Prepare lookup input                        
-                        std::vector<math::polynomial_dfs<typename FieldType::value_type>> lookup_input;
-                        for( const auto &gate:lookup_gates ){
-                            math::expression<DfsVariableType> expr; 
-                            math::polynomial_dfs<typename FieldType::value_type> lookup_selector = plonk_columns.selector(gate.tag_index);
-                            for( const auto &constraint: gate.constraints ){
-                                math::polynomial_dfs<typename FieldType::value_type> l = lookup_selector * (typename FieldType::value_type(constraint.table_id));
-                                theta_acc = theta;
-                                for( std::size_t k = 0; k < constraint.lookup_input.size(); k++){
-                                    expr = converter.convert(constraint.lookup_input[k]);
-                                    math::cached_expression_evaluator<DfsVariableType> evaluator(expr, get_var_value);
-
-                                    l += theta_acc * lookup_selector * evaluator.evaluate();
-                                    theta_acc *= theta;
-                                }
-                                lookup_input.push_back(l);
-                            }
-                        }
-
-                        // 3. Lookup_input and lookup_value are ready
-                        //    Now sort them!
-                        //    Reduce value and input:
-                        std::vector<math::polynomial_dfs<typename FieldType::value_type>> reduced_value;
-                        for( std::size_t i = 0; i < lookup_value.size(); i++ ){
-                            reduced_value.push_back(reduce_dfs_polynomial_domain(lookup_value[i], basic_domain->m));
-                        }
-                        std::vector<math::polynomial_dfs<typename FieldType::value_type>> reduced_input;
-
-                        for( std::size_t i = 0; i < lookup_input.size(); i++ ){
-                            reduced_input.push_back(reduce_dfs_polynomial_domain(lookup_input[i], basic_domain->m));
-                        }
-                        //    Sort
-                        auto sorted = sort_polynomials(reduced_input, reduced_value, basic_domain->m, preprocessed_data.common_data.usable_rows_amount);
-
-                        // 4. Commit sorted polys
-                        for( std::size_t i = 0; i < sorted.size(); i++){
-                            commitment_scheme.append_to_batch(LOOKUP_BATCH, sorted[i]);
-                        }
-                        typename commitment_scheme_type::commitment_type lookup_commitment = commitment_scheme.commit(LOOKUP_BATCH);
-                        transcript(lookup_commitment);
-
-                        //5. Compute V_L polynomial.
-                        typename FieldType::value_type beta  = transcript.template challenge<FieldType>();
-                        typename FieldType::value_type gamma = transcript.template challenge<FieldType>();
-
-                        math::polynomial_dfs<typename FieldType::value_type> V_L(basic_domain->m-1,basic_domain->m, FieldType::value_type::zero());
-                        V_L[0] = FieldType::value_type::one();
-                        auto one = FieldType::value_type::one();
-
-                        for (std::size_t k = 1; k <= preprocessed_data.common_data.usable_rows_amount; k++) {
-                            V_L[k] = V_L[k-1];
-                        
-                            typename FieldType::value_type g_tmp = (one+beta).pow(reduced_input.size());
-                            for( std::size_t i = 0; i < reduced_input.size(); i++){
-                                g_tmp *= gamma + reduced_input[i][k-1];
-                            }
-
-                            auto part1 = (one+beta) * gamma;
-                            for( std::size_t i = 0; i < reduced_value.size(); i++){
-                                g_tmp *= part1 + reduced_value[i][k-1] + beta * reduced_value[i][k];
-                            }
-
-                            V_L[k] *= g_tmp;
-
-                            typename FieldType::value_type h_tmp = FieldType::value_type::one();
-                            for (std::size_t i = 0; i < sorted.size(); i++) {
-                                h_tmp *= part1 + sorted[i][k-1] + beta * sorted[i][k];
-                            }
-                            V_L[k] *= h_tmp.inversed();
-                        }
-                        commitment_scheme.append_to_batch(PERMUTATION_BATCH, V_L);
-
-                        BOOST_CHECK(V_L[preprocessed_data.common_data.usable_rows_amount] ==  FieldType::value_type::one());
-                        
-                        math::polynomial_dfs<typename FieldType::value_type> g = math::polynomial_dfs<typename FieldType::value_type>::one();
-                        g *= (one+beta).pow(lookup_input.size());
-                        
-                        std::vector<math::polynomial_dfs<typename FieldType::value_type>> g_multipliers;
-                        for( std::size_t i = 0; i < lookup_input.size(); i++) {
-                            g_multipliers.push_back(gamma + lookup_input[i]);
-                        }
-
-                        auto part1 = (one+beta) * gamma;
-                        for( std::size_t i = 0; i < lookup_value.size(); i++ ){
-                            auto lookup_shifted = math::polynomial_shift(lookup_value[i], 1, basic_domain->m).get();
-                            g_multipliers.push_back( part1 + lookup_value[i] + beta * lookup_shifted);
-                        }
-
-                        g *= polynomial_product(std::move(g_multipliers));
-
-                        math::polynomial_dfs<typename FieldType::value_type> h;
-                        std::vector<math::polynomial_dfs<typename FieldType::value_type>> h_multipliers;
-                        for( std::size_t i = 0; i < sorted.size(); i++){
-                            auto sorted_shifted = math::polynomial_shift(sorted[i], 1, basic_domain->m).get();
-                            h_multipliers.push_back((one+beta) * gamma + sorted[i] + beta * sorted_shifted);
-                        }
-                        h = polynomial_product(h_multipliers);
-
-                        math::polynomial_dfs<typename FieldType::value_type> V_L_shifted =
-                            math::polynomial_shift(V_L, 1, basic_domain->m).get();
-                        F_dfs[0] = preprocessed_data.common_data.lagrange_0 * (one_polynomial - V_L);
-                        F_dfs[1] = preprocessed_data.q_last * ( V_L * V_L - V_L );
-                        F_dfs[2] = (one_polynomial - (preprocessed_data.q_last + preprocessed_data.q_blind)) *
-                                   (V_L_shifted * h - V_L * g);
-                        F_dfs[3] = zero_polynomial;
-
-                        for( std::size_t i = 1; i < sorted.size(); i++){
-                            typename FieldType::value_type alpha =  transcript.template challenge<FieldType>();
-                            math::polynomial_dfs sorted_shifted = math::polynomial_shift(sorted[i-1], preprocessed_data.common_data.usable_rows_amount , basic_domain->m).get();
-                            F_dfs[3] += alpha * preprocessed_data.common_data.lagrange_0 * (sorted[i] - sorted_shifted);
-                        }
-
-/*                        for( std::size_t i = 0; i < basic_domain->m; i++){
-                            BOOST_CHECK( F_dfs[0].evaluate(basic_domain->get_domain_element(i)) == FieldType::value_type::zero() );
-                            BOOST_CHECK( F_dfs[1].evaluate(basic_domain->get_domain_element(i)) == FieldType::value_type::zero() );
-                            BOOST_CHECK( F_dfs[2].evaluate(basic_domain->get_domain_element(i)) == FieldType::value_type::zero() );
-                            BOOST_CHECK( F_dfs[3].evaluate(basic_domain->get_domain_element(i)) == FieldType::value_type::zero() );
-                        }*/
-
-                        return {
-                            F_dfs,
-                            lookup_commitment
-                        };
-                    }
-
-                    static inline std::array<typename FieldType::value_type, argument_size> verify_eval(
+                public:
+                    std::array<typename FieldType::value_type, argument_size> verify_eval(
                         const typename placeholder_public_preprocessor<FieldType, ParamsType>::preprocessed_data_type &preprocessed_data,
                         const std::vector<plonk_lookup_gate<FieldType, plonk_lookup_constraint<FieldType>>> &lookup_gates,
                         const std::vector<plonk_lookup_table<FieldType>> &lookup_tables,
@@ -541,7 +657,6 @@ namespace nil {
                         return F;
                     }
                 };
-
             }    // namespace snark
         }        // namespace zk
     }            // namespace actor

--- a/include/nil/actor/zk/snark/systems/plonk/placeholder/preprocessor.hpp
+++ b/include/nil/actor/zk/snark/systems/plonk/placeholder/preprocessor.hpp
@@ -518,7 +518,7 @@ namespace nil {
                         transcript(vk.constraint_system_hash);
                         transcript(vk.fixed_values_commitment);
 
-                        nil::crypto3::zk::snark::detail::init_transcript<ParamsType, transcript_hash_type>(
+                        detail::init_transcript<ParamsType, transcript_hash_type>(
                             transcript,
                             common_data.rows_amount,
                             common_data.usable_rows_amount,

--- a/include/nil/actor/zk/snark/systems/plonk/placeholder/preprocessor.hpp
+++ b/include/nil/actor/zk/snark/systems/plonk/placeholder/preprocessor.hpp
@@ -225,11 +225,12 @@ namespace nil {
                     }
 
                     struct cycle_representation {
-                        typedef std::pair<std::size_t, std::size_t> key_type;
+                        // Using std::uint32_t reduces RAM usage a bit. Our table size (rows_amount * width) will never be > 2^32 elements.
+                        typedef std::pair<std::uint32_t, std::uint32_t> key_type;
 
                         std::map<key_type, key_type> _mapping;
                         std::map<key_type, key_type> _aux;
-                        std::map<key_type, std::size_t> _sizes;
+                        std::map<key_type, std::uint32_t> _sizes;
 
                         cycle_representation(
                             const plonk_constraint_system<FieldType, typename ParamsType::arithmetization_params>  &constraint_system,
@@ -367,9 +368,10 @@ namespace nil {
                             S_id[i] = polynomial_dfs_type(
                                 domain->size() - 1, domain->size(), FieldType::value_type::zero());
 
-                            for (std::size_t j = 0; j < domain->size(); j++) {
-                                S_id[i][j] = delta.pow(i) * omega.pow(j);
-                            }
+                            S_id[i][0] = delta.pow(i);
+                            for (std::size_t j = 1; j < domain->size(); j++) {
+                                S_id[i][j] = S_id[i][j-1] * omega;
+                             }
                         }
 
                         return S_id;
@@ -431,7 +433,7 @@ namespace nil {
                     // TODO: columns_with_copy_constraints -- It should be extracted from constraint_system
                     static inline preprocessed_data_type process(
                         const plonk_constraint_system<FieldType, typename ParamsType::arithmetization_params> &constraint_system,
-                        const typename policy_type::variable_assignment_type::public_table_type &public_assignment,
+                        typename policy_type::variable_assignment_type::public_table_type public_assignment,
                         const plonk_table_description<FieldType, typename ParamsType::arithmetization_params>
                             &table_description,
                         typename ParamsType::commitment_scheme_type &commitment_scheme,
@@ -472,11 +474,11 @@ namespace nil {
                             public_polynomial_table =
                                 plonk_public_polynomial_dfs_table<FieldType,
                                                                   typename ParamsType::arithmetization_params>(
-                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.public_inputs(),
+                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.move_public_inputs(),
                                                                                    basic_domain).get(),
-                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.constants(),
+                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.move_constants(),
                                                                                    basic_domain).get(),
-                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.selectors(),
+                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.move_selectors(),
                                                                                    basic_domain).get());
 
                         // prepare commitments for short verifier
@@ -508,14 +510,15 @@ namespace nil {
 
                         typename preprocessed_data_type::verification_key vk = {circuit_hash, public_commitments.fixed_values};
                         typename preprocessed_data_type::common_data_type common_data (
-                            public_commitments, c_rotations,  N_rows, table_description.usable_rows_amount, max_gates_degree, vk
+                            std::move(public_commitments), std::move(c_rotations),
+                            N_rows, table_description.usable_rows_amount, max_gates_degree, vk
                         );
 
-                        transcript_type transcript;
+                        transcript_type transcript(std::vector<std::uint8_t>({}));
                         transcript(vk.constraint_system_hash);
                         transcript(vk.fixed_values_commitment);
 
-                        detail::init_transcript<ParamsType, transcript_hash_type>(
+                        nil::crypto3::zk::snark::detail::init_transcript<ParamsType, transcript_hash_type>(
                             transcript,
                             common_data.rows_amount,
                             common_data.usable_rows_amount,
@@ -551,7 +554,7 @@ namespace nil {
 
                     static inline preprocessed_data_type process(
                         const plonk_constraint_system<FieldType, typename ParamsType::arithmetization_params>  &constraint_system,
-                        const typename policy_type::variable_assignment_type::private_table_type &private_assignment,
+                        typename policy_type::variable_assignment_type::private_table_type private_assignment,
                         const plonk_table_description<FieldType, typename ParamsType::arithmetization_params>  &table_description
                     ) {
                         std::size_t N_rows = table_description.rows_amount;
@@ -561,7 +564,7 @@ namespace nil {
 
                         plonk_private_polynomial_dfs_table<FieldType, typename ParamsType::arithmetization_params>
                             private_polynomial_table(detail::column_range_polynomial_dfs<FieldType>(
-                                private_assignment.witnesses(), basic_domain).get());
+                                private_assignment.move_witnesses(), basic_domain).get());
                         return preprocessed_data_type({basic_domain, std::move(private_polynomial_table)});
                     }
                 };

--- a/include/nil/actor/zk/snark/systems/plonk/placeholder/prover.hpp
+++ b/include/nil/actor/zk/snark/systems/plonk/placeholder/prover.hpp
@@ -99,39 +99,37 @@ namespace nil {
 
                     static inline placeholder_proof<FieldType, ParamsType> process(
                         const typename public_preprocessor_type::preprocessed_data_type &preprocessed_public_data,
-                        const typename private_preprocessor_type::preprocessed_data_type &preprocessed_private_data,
+                        typename private_preprocessor_type::preprocessed_data_type preprocessed_private_data,
                         const plonk_table_description<FieldType, typename ParamsType::arithmetization_params>
                             &table_description,
                         const plonk_constraint_system<FieldType, typename ParamsType::arithmetization_params>
                             &constraint_system,
-                        const typename policy_type::variable_assignment_type &assignments,
                         commitment_scheme_type commitment_scheme
                     ) {
 
                         auto prover = placeholder_prover<FieldType, ParamsType>(
-                            preprocessed_public_data, preprocessed_private_data, table_description,
-                            constraint_system, assignments, commitment_scheme);
+                            preprocessed_public_data, std::move(preprocessed_private_data), table_description,
+                            constraint_system, commitment_scheme);
                         return prover.process();
                     }
 
                     placeholder_prover(
                         const typename public_preprocessor_type::preprocessed_data_type &preprocessed_public_data,
-                        const typename private_preprocessor_type::preprocessed_data_type &preprocessed_private_data,
+                        typename private_preprocessor_type::preprocessed_data_type preprocessed_private_data,
                         const plonk_table_description<FieldType, typename ParamsType::arithmetization_params> &table_description,
                         const plonk_constraint_system<FieldType, typename ParamsType::arithmetization_params> &constraint_system,
-                        const typename policy_type::variable_assignment_type &assignments,
                         const commitment_scheme_type &commitment_scheme
                     )
                             : preprocessed_public_data(preprocessed_public_data)
-                            , preprocessed_private_data(preprocessed_private_data)
                             , table_description(table_description)
                             , constraint_system(constraint_system)
-                            , assignments(assignments)
                             , _commitment_scheme(commitment_scheme)
-                            , _polynomial_table(preprocessed_private_data.private_polynomial_table,
-                                                preprocessed_public_data.public_polynomial_table)
+                            , _polynomial_table(new plonk_polynomial_dfs_table<FieldType, typename ParamsType::arithmetization_params>(
+                                std::move(preprocessed_private_data.private_polynomial_table),
+                                preprocessed_public_data.public_polynomial_table))
+
                             , _is_lookup_enabled(constraint_system.lookup_gates().size() > 0)
-                            , transcript()
+                            , transcript(std::vector<std::uint8_t>({}))
                     {
                         // 1. Add circuit definition to transcript
                         // transcript(short_description);
@@ -140,7 +138,7 @@ namespace nil {
                         transcript(preprocessed_public_data.common_data.vk.constraint_system_hash);
                         transcript(preprocessed_public_data.common_data.vk.fixed_values_commitment);
 
-                        nil::actor::zk::snark::detail::init_transcript<ParamsType, transcript_hash_type>(
+                        nil::crypto3::zk::snark::detail::init_transcript<ParamsType, transcript_hash_type>(
                             transcript,
                             preprocessed_public_data.common_data.rows_amount,
                             preprocessed_public_data.common_data.usable_rows_amount,
@@ -156,8 +154,8 @@ namespace nil {
                         PROFILE_PLACEHOLDER_SCOPE("Placeholder prover, total time");
 
                         // 2. Commit witness columns and public_input columns
-                        _commitment_scheme.append_to_batch(VARIABLE_VALUES_BATCH, _polynomial_table.witnesses());
-                        _commitment_scheme.append_to_batch(VARIABLE_VALUES_BATCH, _polynomial_table.public_inputs());
+                        _commitment_scheme.append_to_batch(VARIABLE_VALUES_BATCH, _polynomial_table->witnesses());
+                        _commitment_scheme.append_to_batch(VARIABLE_VALUES_BATCH, _polynomial_table->public_inputs());
                         {
                             PROFILE_PLACEHOLDER_SCOPE("variable_values_precommit_time");
                             _proof.commitments[VARIABLE_VALUES_BATCH] = _commitment_scheme.commit(VARIABLE_VALUES_BATCH);
@@ -165,24 +163,28 @@ namespace nil {
                         transcript(_proof.commitments[VARIABLE_VALUES_BATCH]);
 
                         // 4. permutation_argument
-                        auto permutation_argument = placeholder_permutation_argument<FieldType, ParamsType>::prove_eval(
-                            constraint_system,
-                            preprocessed_public_data,
-                            table_description,
-                            _polynomial_table,
-                            _commitment_scheme,
-                            transcript).get();
+                        {
+                            auto permutation_argument = placeholder_permutation_argument<FieldType, ParamsType>::prove_eval(
+                                constraint_system,
+                                preprocessed_public_data,
+                                table_description,
+                                *_polynomial_table,
+                                _commitment_scheme,
+                                transcript).get();
 
-                        _F_dfs[0] = std::move(permutation_argument.F_dfs[0]);
-                        _F_dfs[1] = std::move(permutation_argument.F_dfs[1]);
-                        _F_dfs[2] = std::move(permutation_argument.F_dfs[2]);
+                            _F_dfs[0] = std::move(permutation_argument.F_dfs[0]);
+                            _F_dfs[1] = std::move(permutation_argument.F_dfs[1]);
+                            _F_dfs[2] = std::move(permutation_argument.F_dfs[2]);
+                        }
 
                         // 5. lookup_argument
-                        auto lookup_argument_result = lookup_argument();
-                        _F_dfs[3] = std::move(lookup_argument_result.F_dfs[0]);
-                        _F_dfs[4] = std::move(lookup_argument_result.F_dfs[1]);
-                        _F_dfs[5] = std::move(lookup_argument_result.F_dfs[2]);
-                        _F_dfs[6] = std::move(lookup_argument_result.F_dfs[3]);
+                        {
+                            auto lookup_argument_result = lookup_argument();
+                            _F_dfs[3] = std::move(lookup_argument_result.F_dfs[0]);
+                            _F_dfs[4] = std::move(lookup_argument_result.F_dfs[1]);
+                            _F_dfs[5] = std::move(lookup_argument_result.F_dfs[2]);
+                            _F_dfs[6] = std::move(lookup_argument_result.F_dfs[3]);
+                        }
 
                         _proof.commitments[PERMUTATION_BATCH] = _commitment_scheme.commit(PERMUTATION_BATCH);
                         transcript(_proof.commitments[PERMUTATION_BATCH]);
@@ -196,7 +198,7 @@ namespace nil {
                         mask_polynomial -= preprocessed_public_data.q_last;
                         mask_polynomial -= preprocessed_public_data.q_blind;
                         _F_dfs[7] = placeholder_gates_argument<FieldType, ParamsType>::prove_eval(
-                            constraint_system, _polynomial_table,
+                            constraint_system, *_polynomial_table,
                             preprocessed_public_data.common_data.basic_domain,
                             preprocessed_public_data.common_data.max_gates_degree,
                             mask_polynomial,
@@ -208,11 +210,16 @@ namespace nil {
                         placeholder_debug_output();
 #endif
 
-                        // 7. Aggregate quotient polynomial
-                        std::vector<polynomial_dfs_type> T_splitted_dfs =
-                            quotient_polynomial_split_dfs();
+                        // _polynomial_table not needed, clean its memory
+                        _polynomial_table.reset(nullptr);
 
-                        _proof.commitments[QUOTIENT_BATCH] = T_commit(T_splitted_dfs);
+                        // 7. Aggregate quotient polynomial
+                        {
+                            std::vector<polynomial_dfs_type> T_splitted_dfs =
+                                quotient_polynomial_split_dfs();
+
+                            _proof.commitments[QUOTIENT_BATCH] = T_commit(T_splitted_dfs);
+                        }
                         transcript(_proof.commitments[QUOTIENT_BATCH]);
 
                         // 8. Run evaluation proofs
@@ -224,6 +231,7 @@ namespace nil {
                             PROFILE_PLACEHOLDER_SCOPE("commitment scheme proof eval time");
                             _proof.eval_proof.eval_proof = _commitment_scheme.proof_eval(transcript);
                         }
+
                         return _proof;
                     }
 
@@ -237,7 +245,7 @@ namespace nil {
                         PROFILE_PLACEHOLDER_SCOPE("split_polynomial_dfs_conversion_time");
 
                         std::size_t split_polynomial_size = std::max(
-                            (preprocessed_public_data.identity_polynomials.size() + 1) * (preprocessed_public_data.common_data.rows_amount -1 ),
+                            (preprocessed_public_data.identity_polynomials.size() + 2) * (preprocessed_public_data.common_data.rows_amount -1 ),
                             (constraint_system.lookup_poly_degree_bound() + 1) * (preprocessed_public_data.common_data.rows_amount -1 )//,
                         );
                         split_polynomial_size = std::max(
@@ -290,26 +298,30 @@ namespace nil {
                         return T_consolidated;
                     }
 
-                    typename placeholder_lookup_argument<FieldType, commitment_scheme_type, ParamsType>::prover_lookup_result
-                    lookup_argument() {
-                      PROFILE_PLACEHOLDER_SCOPE("lookup_argument_time");
+                    typename placeholder_lookup_argument_prover<FieldType, commitment_scheme_type, ParamsType>::prover_lookup_result
+                        lookup_argument() {
+                        PROFILE_PLACEHOLDER_SCOPE("lookup_argument_time");
 
-                        typename placeholder_lookup_argument<
+                        typename placeholder_lookup_argument_prover<
                             FieldType,
                             commitment_scheme_type,
                             ParamsType>::prover_lookup_result lookup_argument_result;
+
                         lookup_argument_result.F_dfs[0] = polynomial_dfs_type(0, table_description.rows_amount, FieldType::value_type::zero());
                         lookup_argument_result.F_dfs[1] = polynomial_dfs_type(0, table_description.rows_amount, FieldType::value_type::zero());
                         lookup_argument_result.F_dfs[2] = polynomial_dfs_type(0, table_description.rows_amount, FieldType::value_type::zero());
                         lookup_argument_result.F_dfs[3] = polynomial_dfs_type(0, table_description.rows_amount, FieldType::value_type::zero());
-                        if( _is_lookup_enabled ){
-                            lookup_argument_result = placeholder_lookup_argument< FieldType,  commitment_scheme_type, ParamsType>::prove_eval(
+
+                        if (_is_lookup_enabled) {
+                            placeholder_lookup_argument_prover<FieldType, commitment_scheme_type, ParamsType> lookup_argument_prover(
                                 constraint_system,
                                 preprocessed_public_data,
-                                _polynomial_table,
+                                *_polynomial_table,
                                 _commitment_scheme,
                                 transcript
                             );
+;
+                            lookup_argument_result = lookup_argument_prover.prove_eval();
                             _proof.commitments[LOOKUP_BATCH] = lookup_argument_result.lookup_commitment;
                         }
                         return lookup_argument_result;
@@ -336,7 +348,7 @@ namespace nil {
                             for (std::size_t j = 0; j < gates[i].constraints.size(); j++) {
                                 polynomial_dfs_type constraint_result =
                                     gates[i].constraints[j].evaluate(
-                                        _polynomial_table, preprocessed_public_data.common_data.basic_domain) *
+                                        *_polynomial_table, preprocessed_public_data.common_data.basic_domain) *
                                     _polynomial_table.selector(gates[i].selector_index);
                                 // for (std::size_t k = 0; k < table_description.rows_amount; k++) {
                                 if (constraint_result.evaluate(
@@ -374,7 +386,8 @@ namespace nil {
                         if(_is_lookup_enabled){
                             _commitment_scheme.append_eval_point(LOOKUP_BATCH, _proof.eval_proof.challenge);
                             _commitment_scheme.append_eval_point(LOOKUP_BATCH, _proof.eval_proof.challenge * _omega);
-                            _commitment_scheme.append_eval_point(LOOKUP_BATCH, _proof.eval_proof.challenge * _omega.pow(preprocessed_public_data.common_data.usable_rows_amount));
+                            _commitment_scheme.append_eval_point(LOOKUP_BATCH, _proof.eval_proof.challenge *
+                                _omega.pow(preprocessed_public_data.common_data.usable_rows_amount));
                         }
 
                         _commitment_scheme.append_eval_point(QUOTIENT_BATCH, _proof.eval_proof.challenge);
@@ -450,13 +463,11 @@ namespace nil {
                 private:
                     // Structures passed from outside by reference.
                     const typename public_preprocessor_type::preprocessed_data_type &preprocessed_public_data;
-                    const typename private_preprocessor_type::preprocessed_data_type &preprocessed_private_data;
                     const plonk_table_description<FieldType, typename ParamsType::arithmetization_params> &table_description;
                     const plonk_constraint_system<FieldType, typename ParamsType::arithmetization_params> &constraint_system;
-                    const typename policy_type::variable_assignment_type &assignments;
 
                     // Members created during proof generation.
-                    plonk_polynomial_dfs_table<FieldType, typename ParamsType::arithmetization_params> _polynomial_table;
+                    std::unique_ptr<plonk_polynomial_dfs_table<FieldType, typename ParamsType::arithmetization_params>> _polynomial_table;
                     placeholder_proof<FieldType, ParamsType> _proof;
                     std::array<polynomial_dfs_type, f_parts> _F_dfs;
                     transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript;

--- a/include/nil/actor/zk/snark/systems/plonk/placeholder/prover.hpp
+++ b/include/nil/actor/zk/snark/systems/plonk/placeholder/prover.hpp
@@ -138,7 +138,7 @@ namespace nil {
                         transcript(preprocessed_public_data.common_data.vk.constraint_system_hash);
                         transcript(preprocessed_public_data.common_data.vk.fixed_values_commitment);
 
-                        nil::crypto3::zk::snark::detail::init_transcript<ParamsType, transcript_hash_type>(
+                        detail::init_transcript<ParamsType, transcript_hash_type>(
                             transcript,
                             preprocessed_public_data.common_data.rows_amount,
                             preprocessed_public_data.common_data.usable_rows_amount,

--- a/include/nil/actor/zk/snark/systems/plonk/placeholder/verifier.hpp
+++ b/include/nil/actor/zk/snark/systems/plonk/placeholder/verifier.hpp
@@ -169,7 +169,7 @@ namespace nil {
                     ) {
                         // 1. Add circuit definition to transcript
                         // transcript(short_description);
-                        transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript;
+                        transcript::fiat_shamir_heuristic_sequential<transcript_hash_type> transcript(std::vector<std::uint8_t>({}));
                         transcript(preprocessed_public_data.common_data.vk.constraint_system_hash);
                         transcript(preprocessed_public_data.common_data.vk.fixed_values_commitment);
 

--- a/include/nil/actor/zk/snark/systems/plonk/placeholder/verifier.hpp
+++ b/include/nil/actor/zk/snark/systems/plonk/placeholder/verifier.hpp
@@ -94,7 +94,7 @@ namespace nil {
                         _commitment_scheme.append_eval_point(PERMUTATION_BATCH, challenge);
                         _commitment_scheme.append_eval_point(PERMUTATION_BATCH, challenge * _omega);
 
-                        if(_is_lookup_enabled){
+                        if (_is_lookup_enabled) {
                             _commitment_scheme.append_eval_point(LOOKUP_BATCH, challenge);
                             _commitment_scheme.append_eval_point(LOOKUP_BATCH, challenge * _omega);
                             _commitment_scheme.append_eval_point(LOOKUP_BATCH, challenge * _omega.pow(preprocessed_public_data.common_data.usable_rows_amount));
@@ -273,11 +273,9 @@ namespace nil {
                         // 6. lookup argument
                         bool is_lookup_enabled = (constraint_system.lookup_gates().size() > 0);
                         std::array<typename FieldType::value_type, lookup_parts> lookup_argument;
-                        if( is_lookup_enabled ){
-                            lookup_argument = placeholder_lookup_argument<
-                                FieldType, commitment_scheme_type,
-                                ParamsType
-                            >::verify_eval(
+                        if (is_lookup_enabled) {
+                            placeholder_lookup_argument_verifier<FieldType, commitment_scheme_type, ParamsType> lookup_argument_verifier;
+                            lookup_argument = lookup_argument_verifier.verify_eval(
                                 preprocessed_public_data,
                                 constraint_system.lookup_gates(),
                                 constraint_system.lookup_tables(),

--- a/include/nil/actor/zk/transcript/fiat_shamir.hpp
+++ b/include/nil/actor/zk/transcript/fiat_shamir.hpp
@@ -213,7 +213,9 @@ namespace nil {
 
                     template<typename InputRange>
                     fiat_shamir_heuristic_sequential(const InputRange &r) {
-                        sponge.absorb(crypto3::hash<hash_type>(r));
+                        if (r != 0) {
+                           sponge.absorb(crypto3::hash<hash_type>(r));
+                        }
                     }
 
                     template<typename InputIterator>
@@ -245,7 +247,7 @@ namespace nil {
                         auto c = challenge<field_type>();
                         nil::marshalling::status_type status;
 
-                        nil::crypto3::multiprecision::cpp_int intermediate_result = 
+                        nil::crypto3::multiprecision::cpp_int intermediate_result =
                             c.data.template convert_to<nil::crypto3::multiprecision::cpp_int>();
                         Integral result = 0;
                         Integral factor = 1;

--- a/include/nil/actor/zk/transcript/fiat_shamir.hpp
+++ b/include/nil/actor/zk/transcript/fiat_shamir.hpp
@@ -213,7 +213,7 @@ namespace nil {
 
                     template<typename InputRange>
                     fiat_shamir_heuristic_sequential(const InputRange &r) {
-                        if (r != 0) {
+                        if (r.size() != 0) {
                            sponge.absorb(crypto3::hash<hash_type>(r));
                         }
                     }

--- a/test/systems/plonk/placeholder/placeholder.cpp
+++ b/test/systems/plonk/placeholder/placeholder.cpp
@@ -282,16 +282,16 @@ struct placeholder_test_fixture : public test_initializer {
 
         typename placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
             lpc_preprocessed_public_data = placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.public_table(), desc, lpc_scheme, columns_with_copy_constraints.size()
+                constraint_system, assignments.move_public_table(), desc, lpc_scheme, columns_with_copy_constraints.size()
             );
 
         typename placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
             lpc_preprocessed_private_data = placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.private_table(), desc
+                constraint_system, assignments.move_private_table(), desc
             );
 
         auto lpc_proof = placeholder_prover<field_type, lpc_placeholder_params_type>::process(
-            lpc_preprocessed_public_data, lpc_preprocessed_private_data, desc, constraint_system, assignments, lpc_scheme
+            lpc_preprocessed_public_data, std::move(lpc_preprocessed_private_data), desc, constraint_system, lpc_scheme
         );
 
         bool verifier_res = placeholder_verifier<field_type, lpc_placeholder_params_type>::process(
@@ -389,7 +389,7 @@ ACTOR_FIXTURE_TEST_CASE(prover_test, test_initializer){
         );
 
     auto proof = placeholder_prover<field_type, placeholder_params_type>::process(
-        preprocessed_public_data, preprocessed_private_data, desc, constraint_system, assignments, commitment_scheme
+        preprocessed_public_data, std::move(preprocessed_private_data), desc, constraint_system, commitment_scheme
     );
 
     verifier_res = placeholder_verifier<field_type, placeholder_params_type>::process(
@@ -424,18 +424,20 @@ ACTOR_FIXTURE_TEST_CASE(prover_test, test_initializer){
     lpc_scheme_type lpc_scheme(fri_params);
     transcript_type lpc_transcript;
 
+    // Normally we would use "assignments.move_public_table()" here, but assignments are reused in this test.
     typename placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
         lpc_preprocessed_public_data = placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::process(
             constraint_system, assignments.public_table(), desc, lpc_scheme, columns_with_copy_constraints.size()
         );
 
+    // Normally we would use "assignments.move_private_table()" here, but assignments are reused in this test.
     typename placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
         lpc_preprocessed_private_data = placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::process(
             constraint_system, assignments.private_table(), desc
         );
 
     auto lpc_proof = placeholder_prover<field_type, lpc_placeholder_params_type>::process(
-        lpc_preprocessed_public_data, lpc_preprocessed_private_data, desc, constraint_system, assignments, lpc_scheme
+        lpc_preprocessed_public_data, std::move(lpc_preprocessed_private_data), desc, constraint_system, lpc_scheme
     );
 
     verifier_res = placeholder_verifier<field_type, lpc_placeholder_params_type>::process(
@@ -458,7 +460,7 @@ ACTOR_FIXTURE_TEST_CASE(prover_test, test_initializer){
         );
 
     auto kzg_proof = placeholder_prover<field_type, kzg_placeholder_params_type>::process(
-        kzg_preprocessed_public_data, kzg_preprocessed_private_data, desc, constraint_system, assignments, kzg_scheme
+        kzg_preprocessed_public_data, std::move(kzg_preprocessed_private_data), desc, constraint_system, kzg_scheme
     );
 
     verifier_res = placeholder_verifier<field_type, kzg_placeholder_params_type>::process(
@@ -490,12 +492,12 @@ ACTOR_THREAD_TEST_CASE(permutation_polynomials_test) {
 
     typename placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
         lpc_preprocessed_public_data = placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::process(
-            constraint_system, assignments.public_table(), desc, lpc_scheme, columns_with_copy_constraints.size()
+            constraint_system, assignments.move_public_table(), desc, lpc_scheme, columns_with_copy_constraints.size()
         );
 
     typename placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
         lpc_preprocessed_private_data = placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::process(
-            constraint_system, assignments.private_table(), desc
+            constraint_system, assignments.move_private_table(), desc
         );
 
     auto polynomial_table =
@@ -586,12 +588,12 @@ ACTOR_THREAD_TEST_CASE(permutation_argument_test) {
 
     typename placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
         preprocessed_public_data = placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::process(
-            constraint_system, assignments.public_table(), desc, lpc_scheme, permutation_size
+            constraint_system, assignments.move_public_table(), desc, lpc_scheme, permutation_size
         );
 
     typename placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
         preprocessed_private_data = placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::process(
-            constraint_system, assignments.private_table(), desc
+            constraint_system, assignments.move_private_table(), desc
         );
 
     auto polynomial_table =
@@ -836,10 +838,9 @@ ACTOR_THREAD_TEST_CASE(lookup_test_3) {
     transcript_type prover_transcript(init_blob);
     transcript_type verifier_transcript(init_blob);
 
-    auto prover_res =
-        placeholder_lookup_argument<field_type, lpc_scheme_type, lpc_placeholder_params_type>::prove_eval(
-            constraint_system, preprocessed_public_data, polynomial_table, lpc_scheme, prover_transcript
-    );
+    placeholder_lookup_argument_prover<field_type, lpc_scheme_type, lpc_placeholder_params_type> lookup_prover(
+        constraint_system, preprocessed_public_data, polynomial_table, lpc_scheme, prover_transcript);
+    auto prover_res = lookup_prover.prove_eval();
     auto omega = preprocessed_public_data.common_data.basic_domain->get_domain_element(1);
 
     // Challenge phase
@@ -896,8 +897,8 @@ ACTOR_THREAD_TEST_CASE(lookup_test_3) {
             preprocessed_public_data.q_blind.evaluate(y)));
     auto half = prover_res.F_dfs[2].evaluate(y) * special_selectors.inversed();
 
-    std::array<typename field_type::value_type, argument_size> verifier_res =
-    placeholder_lookup_argument<field_type, lpc_type, lpc_placeholder_params_type>::verify_eval(
+    placeholder_lookup_argument_verifier<field_type, lpc_type, lpc_placeholder_params_type> lookup_verifier;
+    std::array<typename field_type::value_type, argument_size> verifier_res = lookup_verifier.verify_eval(
         preprocessed_public_data,
         constraint_system.lookup_gates(),
         constraint_system.lookup_tables(),
@@ -1005,10 +1006,9 @@ ACTOR_THREAD_TEST_CASE(lookup_test_4) {
     transcript_type prover_transcript(init_blob);
     transcript_type verifier_transcript(init_blob);
 
-    auto prover_res =
-        placeholder_lookup_argument<field_type, lpc_scheme_type, lpc_placeholder_params_type>::prove_eval(
-            constraint_system, preprocessed_public_data, polynomial_table, lpc_scheme, prover_transcript
-    );
+    placeholder_lookup_argument_prover<field_type, lpc_scheme_type, lpc_placeholder_params_type> prover(
+            constraint_system, preprocessed_public_data, polynomial_table, lpc_scheme, prover_transcript);
+    auto prover_res = prover.prove_eval();
 
     // Challenge phase
     auto omega = preprocessed_public_data.common_data.basic_domain->get_domain_element(1);
@@ -1065,8 +1065,8 @@ ACTOR_THREAD_TEST_CASE(lookup_test_4) {
             preprocessed_public_data.q_blind.evaluate(y)));
     auto half = prover_res.F_dfs[2].evaluate(y) * special_selectors.inversed();
 
-    std::array<typename field_type::value_type, argument_size> verifier_res =
-    placeholder_lookup_argument<field_type, lpc_type, lpc_placeholder_params_type>::verify_eval(
+    placeholder_lookup_argument_verifier<field_type, lpc_type, lpc_placeholder_params_type> verifier;
+    std::array<typename field_type::value_type, argument_size> verifier_res = verifier.verify_eval(
         preprocessed_public_data,
         constraint_system.lookup_gates(),
         constraint_system.lookup_tables(),


### PR DESCRIPTION
Move changes from crypto3-zk up to commit ebac50db

Changes include memory usage optimizations, improvements in computation of Q and bug fix for expand_factor=0.